### PR TITLE
Grab newPetitions from response

### DIFF
--- a/src/pages/HomePage/index.js
+++ b/src/pages/HomePage/index.js
@@ -72,7 +72,7 @@ function HomePage() {
     const fetchPetitions = async () => {
       const resp = await fetch(url + "/petitions");
       const json = await resp.json();
-      let newPetitions = json.data.petitions;
+      let { newPetitions } = json.data;
 
       setAllPetitions(newPetitions);
       setPetitions(newPetitions);


### PR DESCRIPTION
Parse response for `newPetitions` instead of `petitions` because the signature of the response has changed.

In other words, this handler now returns `newPetitions` so we need to update the frontend.

https://github.com/cqnguy23/Hackathon_Project/blob/d9bf376c84746f769fc8075d2118857b9d23a7f6/controllers/petitions.controller.js#L228
